### PR TITLE
Include python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["LICENSE"]
 
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<=3.12"
 typer = "^0.9.0"
 rich = "^13.7.0"
 tabulate = "^0.9.0"


### PR DESCRIPTION
I'm using Python 3.12, can we allow that in the `pyproject.toml`? 