### PR TITLE
feat(flags): Include --ignore flag for regex folder paths and rework …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ isort = { known-first-party = ["heimdall", "tests"] }
 mccabe = { max-complexity = 10 }
 pydocstyle = { convention = "google" }
 exclude = ["*.ipynb"]
-ignore = ["E203", "E501", "FIX002", "PTH123", "C901", "PD101", "COM812", "PTH118", "PTH207", "PTH207", "UP007"]  # Typer does not support UP007
+ignore = ["E203", "E501", "FIX002", "PTH123", "C901", "PD101", "COM812", "PTH118", "PTH207", "PTH207", "UP007", "B008"]  # Typer does not support UP007
 extend-select = ["Q", "RUF100", "C90", "UP", "I", "T", "B", "F", "Q", "COM812"] # "D",
 extend-ignore = ["D105", "D107", "D205", "D415", "EM101", "G004", "ARG001", "ARG002", "PD901", "RET504"]
 fixable = ["F", "N", "D", "W", "INP", "PLC", "PLR", "PLW", "RUF", "SIM", "Q", "UP", "TID", "I", "EM", "FBT", "PD", "E501"]

--- a/src/rejx/__init__.py
+++ b/src/rejx/__init__.py
@@ -1,24 +1,15 @@
 from rejx.cli import (
     app,
-    apply_changes,
-    build_file_tree,
     clean,
     diff,
-    find_rej_files,
     fix,
     ls,
-    parse_rej_file,
-    process_rej_file,
 )
 
 __all__ = [
-    "apply_changes",
-    "build_file_tree",
+    "app",
     "clean",
     "diff",
-    "find_rej_files",
     "fix",
     "ls",
-    "parse_rej_file",
-    "process_rej_file",
 ]

--- a/src/rejx/cli.py
+++ b/src/rejx/cli.py
@@ -2,196 +2,38 @@
 
 from __future__ import annotations
 
-import glob
-import logging
-import os
 import pathlib
-import re
 from difflib import unified_diff
 from typing import Optional
 
 import typer
 from rich.console import Console
-from rich.logging import RichHandler
 from rich.prompt import Confirm
 from rich.syntax import Syntax
 from rich.text import Text
-from rich.tree import Tree
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(message)s",
-    datefmt="[%X]",
-    handlers=[RichHandler(rich_tracebacks=True)],
-)
+import rejx.utils
+from rejx.logger import logger
 
 app = typer.Typer()
 
 
-def find_rej_files(hidden_files: bool = True) -> list[str]:
-    """Finds all .rej files in the current directory and its subdirectories.
-
-    Returns:
-    -------
-        list[str]: A list of file paths to the found .rej files.
-
-    Example:
-    -------
-        ```python
-        rej_files = find_rej_files()
-        print(rej_files)  # Prints paths to all .rej files.
-        ```
-    """
-    if hidden_files:
-        return glob.glob("**/*.rej", recursive=True) + glob.glob("**/.*.rej", recursive=True)
-    return glob.glob("**/*.rej", recursive=True)
-
-
-def parse_rej_file(rej_file_path: str) -> list[str]:
-    """Parses a .rej file and returns its lines.
-
-    Args:
-    ----
-        rej_file_path (str): The path to the .rej file.
-
-    Returns:
-    -------
-        list[str]: A list of lines from the .rej file.
-
-    Raises:
-    ------
-        typer.Exit: If the .rej file is not found.
-
-    Example:
-    -------
-        ```python
-        rej_lines = parse_rej_file("path/to/file.rej")
-        print(rej_lines)  # Prints the contents of the .rej file.
-        ```
-    """
-    try:
-        with open(rej_file_path, encoding="utf-8") as file:
-            return file.readlines()
-    except FileNotFoundError:
-        logging.exception(f"File not found: {rej_file_path}")
-        raise typer.Exit from FileNotFoundError
-
-
-def apply_changes(target_lines: list[str], rej_lines: list[str]) -> list[str]:
-    """Applies the changes from .rej file lines to the target file's lines.
-
-    Args:
-    ----
-        target_lines (list[str]): The lines from the target file.
-        rej_lines (list[str]): The lines from the .rej file.
-
-    Returns:
-    -------
-        list[str]: The modified lines after applying the .rej file changes.
-
-    Example:
-    -------
-        ```python
-        target_lines = ["line1", "line2", "line3"]
-        rej_lines = ["@@ -1,1 +1,1 @@", "- line1", "+ line1_modified"]
-        modified_lines = apply_changes(target_lines, rej_lines)
-        print(modified_lines)  # Prints the modified lines.
-        ```
-    """
-    line_info_regex = r"@@ -(\d+),(\d+) \+(\d+),(\d+) @@"
-    hunk_start = 0
-    new_lines = []
-    current_hunk_changes = []
-    processing_hunk = False
-
-    for line in rej_lines:
-        if line.startswith("@@"):
-            # Process the previous hunk
-            if processing_hunk:
-                # Replace the lines in the target file for this hunk
-                new_lines.extend(current_hunk_changes)
-                current_hunk_changes = []
-
-            # Parse hunk header
-            matches = re.search(line_info_regex, line)
-            if matches:
-                hunk_start = int(matches.group(1)) - 1
-                processing_hunk = True
-
-                # Add lines from the target file up to the start of this hunk
-                new_lines.extend(target_lines[len(new_lines) : hunk_start])
-                continue
-
-        chunks_not_in_rej_file = len(new_lines) + len(current_hunk_changes) < len(
-            target_lines,
-        )
-
-        if processing_hunk:
-            if line.startswith("+"):
-                # Added lines
-                current_hunk_changes.append(line[1:].rstrip("\n") + "\n")
-            # Context line: keep this line from the original file
-            elif not line.startswith("-") and chunks_not_in_rej_file:
-                current_hunk_changes.append(
-                    target_lines[len(new_lines) + len(current_hunk_changes)],
-                )
-
-    # Apply the last hunk
-    if processing_hunk:
-        new_lines.extend(current_hunk_changes)
-
-    # Add any remaining lines from the original file
-    new_lines.extend(target_lines[len(new_lines) :])
-
-    return new_lines
-
-
-def process_rej_file(rej_file_path: str) -> bool:
-    """Processes a .rej file by applying its changes to the corresponding original file.
-
-    Args:
-    ----
-        rej_file_path (str): The path to the .rej file.
-
-    Returns:
-    -------
-        bool: True if the process is successful, False otherwise.
-
-    Example:
-    -------
-        ```python
-        success = process_rej_file("path/to/file.rej")
-        if success:
-            print("Changes applied successfully.")
-        else:
-            print("Failed to apply changes.")
-        ```
-    """
-    success = False
-
-    try:
-        target_file_path = rej_file_path.replace(".rej", "")
-        rej_lines = parse_rej_file(rej_file_path)
-        with open(target_file_path, encoding="utf-8") as file:
-            target_lines = file.readlines()
-
-        modified_lines = apply_changes(target_lines, rej_lines)
-
-        with open(target_file_path, "w", encoding="utf-8") as file:
-            file.writelines(modified_lines)
-
-        logging.info(f"Applied changes from {rej_file_path} to {target_file_path}")
-        success = True
-    except Exception:
-        logging.exception(f"Error processing {rej_file_path}")
-
-    return success
-
-
 @app.command()
 def fix(
-    rej_files: list[str] = typer.Argument(default=None),  # noqa: B008
-    apply_to_all_files: Optional[bool] = typer.Option(False, "--all", help="Apply changes from all .rej files.", show_default=False),
+    rej_files: list[str] = typer.Argument(default=None),
+    apply_to_all_files: Optional[bool] = typer.Option(
+        False,
+        "--all",
+        help="Apply changes from all .rej files.",
+        show_default=False,
+    ),
+    exclude_hidden: Optional[bool] = typer.Option(
+        False,
+        "--exclude-hidden",
+        help="Hide hidden files.",
+        show_default=False,
+    ),
+    ignore: Optional[list[str]] = typer.Option(None, "--ignore", help="Regex patterns to ignore directories"),
 ) -> None:
     """Applies changes from a specified .rej file to its corresponding original file.
 
@@ -199,6 +41,8 @@ def fix(
     ----
         rej_file (str): The path to the .rej file to be processed.
         apply_to_all_files (Optional[bool]): Determines whether all files should be fixed. Default: False.
+        exclude_hidden (Optional[bool]): Determines whether to hide hidden files from output. Defaults to `False`
+        ignore(Optional[List[str]]): List of regex patterns of directories to ignore rej files from.
 
     Example:
     -------
@@ -213,24 +57,40 @@ def fix(
         ```
     """
     if apply_to_all_files:
-        for rej_file in find_rej_files():
-            process_rej_file(rej_file)
+        for rej_file in rejx.utils.find_rej_files(
+            exclude_hidden=exclude_hidden,
+            ignore=ignore,
+        ):
+            rejx.utils.process_rej_file(rej_file)
 
     elif rej_files is None:
-        logging.error("No file name specified")
+        logger.error("No file name specified")
 
     else:
         for rej_file in rej_files:
-            process_rej_file(rej_file)
+            rejx.utils.process_rej_file(rej_file)
 
 
 @app.command()
 def diff(
-    rej_files: list[str] = typer.Argument(default=None),  # noqa: B008
+    rej_files: list[str] = typer.Argument(default=None),
+    exclude_hidden: Optional[bool] = typer.Option(
+        False,
+        "--exclude-hidden",
+        help="Hide hidden files.",
+        show_default=False,
+    ),
+    ignore: Optional[list[str]] = typer.Option(None, "--ignore", help="Regex patterns to ignore directories"),
 ) -> None:
     """Displays the diff of changes proposed by .rej files against their corresponding original files.
 
-        Displays the diff for all .rej files If no file names are specified.
+    Displays the diff for all .rej files If no file names are specified.
+
+    Args:
+    -----
+        rej_files (list[str]): Rej files to apply diff.
+        exclude_hidden (Optional[bool]): Determines whether to hide hidden files from output. Defaults to `False`
+        ignore(Optional[List[str]]): List of regex patterns of directories to ignore rej files from.
 
     Example:
     -------
@@ -240,7 +100,10 @@ def diff(
         ```
     """
     if rej_files is None:
-        rej_files = find_rej_files()
+        rej_files = rejx.utils.find_rej_files(
+            exclude_hidden=exclude_hidden,
+            ignore=ignore,
+        )
 
     console = Console()
     file_logs = []
@@ -248,11 +111,11 @@ def diff(
     for rej_file in rej_files:
         try:
             target_file_path = rej_file.replace(".rej", "")
-            rej_lines = parse_rej_file(rej_file)
+            rej_lines = rejx.utils.parse_rej_file(rej_file)
             with open(target_file_path, encoding="utf-8") as file:
                 target_lines = file.readlines()
 
-            modified_lines = apply_changes(target_lines.copy(), rej_lines)
+            modified_lines = rejx.utils.apply_changes(target_lines.copy(), rej_lines)
             diff = "".join(
                 unified_diff(
                     target_lines,
@@ -266,7 +129,7 @@ def diff(
             file_logs.append({"filename": rej_file, "diff": diff})
 
         except Exception:  # noqa: PERF203
-            logging.exception(f"Error in previewing {rej_file}")
+            logger.exception(f"Error in previewing {rej_file}")
 
     # Display diff
     with console.pager(styles=True):
@@ -291,60 +154,15 @@ def diff(
             )
 
 
-def build_file_tree(rej_files: list) -> Tree:
-    """Constructs a tree structure representing the hierarchy of the provided .rej files.
-
-    This tree structure visually organizes the .rej files based on their directory structure.
-    It is used primarily for displaying the files in a tree format when using the `ls` command with the `--view tree` option.
-
-    Args:
-    ----
-        rej_files (list): A list of file paths to .rej files.
-
-    Returns:
-    -------
-        Tree: A rich Tree object representing the hierarchy of .rej files.
-
-    Example:
-    -------
-        This function is generally not called directly by the user but used as part of the `ls` command:
-        ```bash
-        rejx ls --view tree
-        ```
-        Internally, it would be used as follows:
-        ```python
-        rej_files = find_rej_files()
-        tree = build_file_tree(rej_files)
-        console.print(tree)
-        ```
-    """
-    tree = Tree(
-        ":open_file_folder: Rejected Files Tree",
-        guide_style="bold bright_blue",
-    )
-    node_dict = {}
-
-    for rej_file in rej_files:
-        path_parts = pathlib.Path(rej_file).parts
-        current_node = tree
-
-        for part in path_parts:
-            key = os.path.join(
-                *path_parts[: path_parts.index(part) + 1],
-            )
-            if key not in node_dict:
-                # If part is a directory, color it blue/purple
-                is_dir = part != path_parts[-1]
-                style = "bold bright_blue" if is_dir else ""
-                node_dict[key] = current_node.add(Text(part, style=style))
-            current_node = node_dict[key]
-
-    return tree
-
-
 @app.command()
 def ls(
-    hidden_files: Optional[bool] = typer.Option(True, "--no-hidden", help="Skip hidden files.", show_default=False),
+    exclude_hidden: Optional[bool] = typer.Option(
+        False,
+        "--exclude-hidden",
+        help="Hide hidden files.",
+        show_default=False,
+    ),
+    ignore: Optional[list[str]] = typer.Option(None, "--ignore", help="Regex patterns to ignore directories"),
     view: Optional[str] = typer.Option("list", help="View as 'list' or 'tree'"),
 ) -> None:
     """Lists all .rej files in the current directory and subdirectories.
@@ -353,8 +171,9 @@ def ls(
 
     Args:
     ----
-        hidden_files (Optional[bool], optional): Determines whether hidden files should be shown. Defaults to `True`.
-        view (Optional[str], optional): The view format. Can be 'list' or 'tree'. Defaults to 'list'.
+        exclude_hidden (Optional[bool]): Determines whether to hide hidden files from output. Defaults to `False`
+        ignore(Optional[List[str]]): List of regex patterns of directories to ignore rej files from.
+        view (Optional[str]): The view format. Can be 'list' or 'tree'. Defaults to 'list'.
 
     Example:
     -------
@@ -367,7 +186,10 @@ def ls(
           rejx ls --view tree
           ```
     """
-    rej_files = find_rej_files(hidden_files=hidden_files)
+    rej_files = rejx.utils.find_rej_files(
+        exclude_hidden=exclude_hidden,
+        ignore=ignore,
+    )
     console = Console()
 
     if not rej_files:
@@ -378,7 +200,7 @@ def ls(
         for file in rej_files:
             console.print(file)
     elif view == "tree":
-        tree = build_file_tree(rej_files)
+        tree = rejx.utils.build_file_tree(rej_files)
         console.print(tree)
     else:
         console.print(f"[bold red]Invalid view option: {view}.[/bold red]")
@@ -387,12 +209,24 @@ def ls(
 
 @app.command()
 def clean(
-    rej_files: list[str] = typer.Argument(default=None),  # noqa: B008
-    apply_to_all_files: Optional[bool] = typer.Option(False, "--all", help="Apply changes from all .rej files.", show_default=False),
+    rej_files: list[str] = typer.Argument(default=None),
+    apply_to_all_files: Optional[bool] = typer.Option(
+        False,
+        "--all",
+        help="Apply changes from all .rej files.",
+        show_default=False,
+    ),
     preview: bool = typer.Option(
         False,
         help="Preview files before deleting",
     ),
+    exclude_hidden: Optional[bool] = typer.Option(
+        False,
+        "--exclude-hidden",
+        help="Hide hidden files.",
+        show_default=False,
+    ),
+    ignore: Optional[list[str]] = typer.Option(None, "--ignore", help="Regex patterns to ignore directories"),
 ) -> None:
     """Deletes one or all .rej files in the current directory and subdirectories.
 
@@ -403,6 +237,8 @@ def clean(
         rej_files (Optional, List[str]): a list of names of files to be deleted.
         apply_to_all_files (Optional, bool): determines if all files should be removed. Defaults to "False".
         preview (bool): If True, previews the files before deleting. Defaults to False.
+        exclude_hidden (Optional[bool]): Determines whether to hide hidden files from output. Defaults to `False`
+        ignore(Optional[List[str]]): List of regex patterns of directories to ignore rej files from.
 
     Example:
     -------
@@ -420,10 +256,13 @@ def clean(
           ```
     """
     if apply_to_all_files:
-        rej_files = find_rej_files()
+        rej_files = rejx.utils.find_rej_files(
+            exclude_hidden=exclude_hidden,
+            ignore=ignore,
+        )
 
     elif rej_files is None:
-        logging.error("No filename specified.")
+        logger.error("No filename specified.")
 
     console = Console()
 

--- a/src/rejx/logger.py
+++ b/src/rejx/logger.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import logging
+
+from rich.logging import RichHandler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[RichHandler(rich_tracebacks=True)],
+)
+
+console = logging.StreamHandler()
+console.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter("%(name)-12s: %(levelname)-8s %(message)s'")
+console.setFormatter(formatter)
+logging.getLogger("").addHandler(console)
+
+logger = logging.getLogger(__name__)

--- a/src/rejx/utils.py
+++ b/src/rejx/utils.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import glob
+import os
+import pathlib
+import re
+from typing import Optional
+
+import typer
+from rich.text import Text
+from rich.tree import Tree
+
+from rejx.logger import logger
+
+
+def find_rej_files(
+    *,
+    exclude_hidden: bool | None = True,
+    ignore: Optional[list[str]] = None,
+) -> list[str]:
+    """Finds all .rej files in the current directory and its subdirectories.
+
+    Args:
+    ----
+        exclude_hidden (bool): Include hidden files.
+        ignore(Optional[List[str]]): List of regex patterns of directories to ignore rej files from.
+
+    Returns:
+    -------
+        list[str]: A list of file paths to the found .rej files.
+
+    Example:
+    -------
+        ```python
+        rej_files = find_rej_files()
+        print(rej_files)  # Prints paths to all .rej files.
+        ```
+    """
+    rej_file_matches = glob.glob("**/*.rej", recursive=True)
+    if not exclude_hidden:
+        rej_file_matches += glob.glob("**/.*.rej", recursive=True)
+
+    filtered_files = [f for f in rej_file_matches if not any(re.search(pattern, f) for pattern in ignore or [])]
+
+    return filtered_files
+
+
+def parse_rej_file(rej_file_path: str) -> list[str]:
+    """Parses a .rej file and returns its lines.
+
+    Args:
+    ----
+        rej_file_path (str): The path to the .rej file.
+
+    Returns:
+    -------
+        list[str]: A list of lines from the .rej file.
+
+    Raises:
+    ------
+        typer.Exit: If the .rej file is not found.
+
+    Example:
+    -------
+        ```python
+        rej_lines = parse_rej_file("path/to/file.rej")
+        print(rej_lines)  # Prints the contents of the .rej file.
+        ```
+    """
+    try:
+        with open(rej_file_path, encoding="utf-8") as file:
+            return file.readlines()
+    except FileNotFoundError:
+        logger.exception(f"File not found: {rej_file_path}")
+        raise typer.Exit from FileNotFoundError
+
+
+def apply_changes(
+    target_lines: list[str],
+    rej_lines: list[str],
+) -> list[str]:
+    """Applies the changes from .rej file lines to the target file's lines.
+
+    Args:
+    ----
+        target_lines (list[str]): The lines from the target file.
+        rej_lines (list[str]): The lines from the .rej file.
+
+    Returns:
+    -------
+        list[str]: The modified lines after applying the .rej file changes.
+
+    Example:
+    -------
+        ```python
+        target_lines = ["line1", "line2", "line3"]
+        rej_lines = ["@@ -1,1 +1,1 @@", "- line1", "+ line1_modified"]
+        modified_lines = apply_changes(target_lines, rej_lines)
+        print(modified_lines)  # Prints the modified lines.
+        ```
+    """
+    line_info_regex = r"@@ -(\d+),(\d+) \+(\d+),(\d+) @@"
+    hunk_start = 0
+    new_lines = []
+    current_hunk_changes = []
+    processing_hunk = False
+
+    for line in rej_lines:
+        if line.startswith("@@"):
+            # Process the previous hunk
+            if processing_hunk:
+                # Replace the lines in the target file for this hunk
+                new_lines.extend(current_hunk_changes)
+                current_hunk_changes = []
+
+            # Parse hunk header
+            matches = re.search(line_info_regex, line)
+            if matches:
+                hunk_start = int(matches.group(1)) - 1
+                processing_hunk = True
+
+                # Add lines from the target file up to the start of this hunk
+                new_lines.extend(target_lines[len(new_lines) : hunk_start])
+                continue
+
+        LINES_NOT_IN_REJ_FILE = len(new_lines) + len(current_hunk_changes)
+
+        chunks_not_in_rej_file = len(target_lines) > LINES_NOT_IN_REJ_FILE
+
+        if processing_hunk:
+            if line.startswith("+"):
+                # Added lines
+                current_hunk_changes.append(line[1:].rstrip("\n") + "\n")
+            # Context line: keep this line from the original file
+            elif not line.startswith("-") and chunks_not_in_rej_file:
+                current_hunk_changes.append(target_lines[LINES_NOT_IN_REJ_FILE])
+
+    # Apply the last hunk
+    if processing_hunk:
+        new_lines.extend(current_hunk_changes)
+
+    # Add any remaining lines from the original file
+    new_lines.extend(target_lines[len(new_lines) :])
+
+    return new_lines
+
+
+def process_rej_file(rej_file_path: str) -> bool:
+    """Processes a .rej file by applying its changes to the corresponding original file.
+
+    Args:
+    ----
+        rej_file_path (str): The path to the .rej file.
+
+    Returns:
+    -------
+        bool: True if the process is successful, False otherwise.
+
+    Example:
+    -------
+        ```python
+        success = process_rej_file("path/to/file.rej")
+        if success:
+            print("Changes applied successfully.")
+        else:
+            print("Failed to apply changes.")
+        ```
+    """
+    success = False
+
+    try:
+        target_file_path = rej_file_path.replace(".rej", "")
+        rej_lines = parse_rej_file(rej_file_path)
+        with open(target_file_path, encoding="utf-8") as file:
+            target_lines = file.readlines()
+
+        modified_lines = apply_changes(target_lines, rej_lines)
+
+        with open(target_file_path, "w", encoding="utf-8") as file:
+            file.writelines(modified_lines)
+
+        logger.info(f"Applied changes from {rej_file_path} to {target_file_path}")
+        success = True
+    except Exception:
+        logger.exception(f"Error processing {rej_file_path}")
+
+    return success
+
+
+def build_file_tree(rej_files: list) -> Tree:
+    """Constructs a tree structure representing the hierarchy of the provided .rej files.
+
+    This tree structure visually organizes the .rej files based on their directory structure.
+    It is used primarily for displaying the files in a tree format when using the `ls` command with the `--view tree` option.
+
+    Args:
+    ----
+        rej_files (list): A list of file paths to .rej files.
+
+    Returns:
+    -------
+        Tree: A rich Tree object representing the hierarchy of .rej files.
+
+    Example:
+    -------
+        This function is generally not called directly by the user but used as part of the `ls` command:
+        ```bash
+        rejx ls --view tree
+        ```
+        Internally, it would be used as follows:
+        ```python
+        rej_files = find_rej_files()
+        tree = build_file_tree(rej_files)
+        console.print(tree)
+        ```
+    """
+    tree = Tree(
+        ":open_file_folder: Rejected Files Tree",
+        guide_style="bold bright_blue",
+    )
+    node_dict = {}
+
+    for rej_file in rej_files:
+        path_parts = pathlib.Path(rej_file).parts
+        current_node = tree
+
+        for part in path_parts:
+            key = os.path.join(
+                *path_parts[: path_parts.index(part) + 1],
+            )
+            if key not in node_dict:
+                # If part is a directory, color it blue/purple
+                is_dir = part != path_parts[-1]
+                style = "bold bright_blue" if is_dir else ""
+                node_dict[key] = current_node.add(Text(part, style=style))
+            current_node = node_dict[key]
+
+    return tree

--- a/tests/data/.hidden-sample.txt
+++ b/tests/data/.hidden-sample.txt
@@ -1,0 +1,3 @@
+Line 1
+Line 2 - Modified
+Line 3

--- a/tests/data/.hidden-sample.txt.rej
+++ b/tests/data/.hidden-sample.txt.rej
@@ -1,0 +1,6 @@
+--- sample.txt
++++ sample.txt
+@@ -2,3 +2,3 @@
+-Line 2
++Line 2 - Modified
+Line 3

--- a/tests/test_rejx.py
+++ b/tests/test_rejx.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-import rejx
+import rejx.utils
 from rejx import app
 
 # Constants
@@ -47,13 +47,13 @@ def _setup_sample_rej_file() -> None:
 
 def test_find_rej_files():
     os.chdir(TEST_DATA_DIR)  # Change current directory to test data directory
-    rej_files = rejx.find_rej_files()
+    rej_files = rejx.utils.find_rej_files()
     assert len(rej_files) > 0
     assert all(file.endswith(".rej") for file in rej_files)
 
 
 def test_parse_rej_file(sample_rej_file: str):
-    rej_lines = rejx.parse_rej_file(sample_rej_file)
+    rej_lines = rejx.utils.parse_rej_file(sample_rej_file)
     assert rej_lines is not None
     assert isinstance(rej_lines, list)
 
@@ -61,8 +61,8 @@ def test_parse_rej_file(sample_rej_file: str):
 def test_apply_changes(sample_rej_file: str, sample_target_file: str):
     with open(sample_target_file, encoding="utf-8") as f:
         target_lines = f.readlines()
-    rej_lines = rejx.parse_rej_file(sample_rej_file)
-    modified_lines = rejx.apply_changes(target_lines, rej_lines)
+    rej_lines = rejx.utils.parse_rej_file(sample_rej_file)
+    modified_lines = rejx.utils.apply_changes(target_lines, rej_lines)
 
     expected_lines = ["Line 1\n", "Line 2 - Modified\n", "Line 3\n"]
 
@@ -71,7 +71,7 @@ def test_apply_changes(sample_rej_file: str, sample_target_file: str):
 
 
 def test_process_rej_file(sample_rej_file: str):
-    result = rejx.process_rej_file(sample_rej_file)
+    result = rejx.utils.process_rej_file(sample_rej_file)
     assert result
 
 
@@ -106,12 +106,12 @@ def test_ls_tree():
 
 
 def test_clean():
-    result = runner.invoke(app, ["clean","--all"])
+    result = runner.invoke(app, ["clean", "--all"])
     assert result.exit_code == 0
 
 
 def test_clean_with_preview():
-    result = runner.invoke(app, ["clean","all", "--preview"], input="y\n")
+    result = runner.invoke(app, ["clean", "all", "--preview"], input="y\n")
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Overview

- Includes one new flag: `--ignore` to allow one to ignore one or several folders based on regex path of a folder to ignore
- Reworks the `--show-hidden` flag. Instead, make it align with python's Pathlib and glob and use `--include-hidden/--exclude-hidden`
- Moves utility methods for the CLI args to it's own file